### PR TITLE
[Fix] Sandbox permissions

### DIFF
--- a/io.github.aandrew_me.ytdn.yml
+++ b/io.github.aandrew_me.ytdn.yml
@@ -11,7 +11,6 @@ separate-locales: false
 finish-args:
   - --share=ipc
   - --socket=x11
-  - --filesystem=home
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=com.canonical.AppMenu.Registrar
   - --talk-name=org.kde.StatusNotifierWatcher

--- a/io.github.aandrew_me.ytdn.yml
+++ b/io.github.aandrew_me.ytdn.yml
@@ -11,6 +11,7 @@ separate-locales: false
 finish-args:
   - --share=ipc
   - --socket=x11
+  - --persist=.ytDownloader
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=com.canonical.AppMenu.Registrar
   - --talk-name=org.kde.StatusNotifierWatcher

--- a/io.github.aandrew_me.ytdn.yml
+++ b/io.github.aandrew_me.ytdn.yml
@@ -12,6 +12,7 @@ finish-args:
   - --share=ipc
   - --socket=x11
   - --persist=.ytDownloader
+  - --filesystem=xdg-download
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=com.canonical.AppMenu.Registrar
   - --talk-name=org.kde.StatusNotifierWatcher


### PR DESCRIPTION
Currently the application is using `home` which is really bad and clutters the user home folder. 

This PR addresses that issue where `.ytDownloader` is persistent (i.e. not deleted and writeable) while being in the flatpak sandbox: `~/.var/app/io.github.aandrew_me.ytdn/.ytDownloader` instead of just `~/.ytDownloader` and also allowing for `xdg-download` for the default Downloads folder.

This application does actually use portals (nice) so setting custom download locations shouldn't be an issue, although I have not yet tested out after rebooting my system (I will test it tomorrow as the next poweroff I do will be during my sleep). 